### PR TITLE
Update hubitat-mqtt-bridge-app.groovy

### DIFF
--- a/apps/hubitat-mqtt-bridge-app.groovy
+++ b/apps/hubitat-mqtt-bridge-app.groovy
@@ -51,11 +51,12 @@ import groovy.transform.Field
             "presence"
         ]
     ],
-    "button": [
-        name: "Button",
-        capability: "capability.button",
+    "pushablebutton": [
+        name: "Pushable Button",
+        capability: "capability.pushableButton",
         attributes: [
-            "button"
+            "pushed",
+            "released"
         ]
     ],
     "carbonDioxideMeasurement": [
@@ -213,6 +214,13 @@ import groovy.transform.Field
         capability: "capability.relativeHumidityMeasurement",
         attributes: [
             "humidity"
+        ]
+    ],
+        "pressureSensors": [
+        name: "Pressure",
+        capability: "capability.relativeHumidityMeasurement",
+        attributes: [
+            "pressure"
         ]
     ],
     "relaySwitch": [


### PR DESCRIPTION
Two changes:

1. use the new [Hubitat button model](https://community.hubitat.com/t/hubitats-button-implementation/283)
2. added support for a sensor that reports air pressure.  Unfortunately, the driver for this only has the `relativeHumidity` capability.  see [here](https://github.com/veeceeoh/xiaomi-hubitat/blob/master/devicedrivers/xiaomi-temperature-humidity-sensor-hubitat.src/xiaomi-temperature-humidity-sensor-hubitat.groovy)